### PR TITLE
Create LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/src/Frame/Footer/Footer.js
+++ b/src/Frame/Footer/Footer.js
@@ -12,8 +12,8 @@ export default function Footer() {
           Github
         </a>
         .<br className={style.breakWhenSmall} /> All code presented is under the{' '}
-        <a href="https://opensource.org/licenses/MIT" rel="noreferrer">
-          MIT license
+        <a href="https://github.com/theScottyJam/snap.js/blob/main/license" rel="noreferrer">
+          "unlicense" license
         </a>
         .
       </p>


### PR DESCRIPTION
Add a license file.

I'm switching to the "unlicense" license, as this doesn't require you to preserve attribution, which would be anoying to do with copy-paste utility functions.

Resolves #9